### PR TITLE
Added support for default values for maxwidth / height in the case the p...

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -78,9 +78,13 @@
         url += (url.indexOf("?") <= 0) ? "?" : "&";
         url = url.replace('#','%23');
 
-        if (provider.maxWidth !== null && provider.params.maxwidth === null) provider.params.maxwidth = provider.maxWidth;
+        if (provider.maxWidth !== null && (typeof provider.params.maxwidth === 'undefined' || provider.params.maxwidth === null)) {
+            provider.params.maxwidth = provider.maxWidth;
+        }
 
-        if (provider.maxHeight !== null && provider.params.maxheight === null) provider.params.maxheight = provider.maxHeight;
+        if (provider.maxHeight !== null && (typeof provider.params.maxheight === 'undefined' || provider.params.maxheight === null)) {
+            provider.params.maxheight = provider.maxHeight;
+        }
 
         for (i in provider.params) {
             // We don't want them to jack everything up by changing the callback parameter


### PR DESCRIPTION
...arams are not defined - closes #15

For instance, calling the oembed method with the following url http://vimeo.com/17439665 and the options below did not restricted the width / height :

```
{
    maxHeight: 150,
    maxWidth: 550
}
```
