### PR TITLE
Several changes I made. Sorry for the 1 big commit, I wasn't tracking the changes in git as I made them originally.

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -46,7 +46,6 @@
                 provider;
 
             if (embedAction) {
-				console.log("setting action");
                 settings.onEmbed = embedAction;
             }
             else if (!settings.onEmbed){
@@ -384,10 +383,15 @@
             , datareturn:function(results){return results.html.replace(/.*\[CDATA\[(.*)\]\]>$/,'$1') || ''}
             };
           }else{
-            extraSettings.yql = {xpath:"json.html", from:'json'
+            extraSettings.yql = {from:'json'
               , apiendpoint: this.apiendpoint
               , url: function(externalurl){return this.apiendpoint+'?format=json&url='+externalurl}
-              , datareturn:function(results){return results.html || ''}
+              , datareturn:function(results){
+					if ("url" in results.json) {
+						return '<img src="' + results.json.url + '" />';
+					}
+					return results.json.html || ''
+				}
             };
           }
           this.apiendpoint = null;

--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -46,6 +46,7 @@
                 provider;
 
             if (embedAction) {
+				console.log("setting action");
                 settings.onEmbed = embedAction;
             }
             else if (!settings.onEmbed){
@@ -323,8 +324,11 @@
 				  });
 			  }
               oembedContainer.append('<br/>');
-			  oembedData.code.clone().appendTo(oembedContainer);
-              // oembedContainer.append(oembedData.code);
+			  try {
+				  oembedData.code.clone().appendTo(oembedContainer);
+			  } catch(e) {
+              oembedContainer.append(oembedData.code);
+			  }			
               if(settings.maxWidth)oembedContainer.css('max-width',settings.maxWidth);
               if(settings.maxHeight)oembedContainer.css('max-height',settings.maxHeight);
               break;


### PR DESCRIPTION
unscatter.com. I've decided to do a pull request in order to
contribute some of the fixes back to project.

1: Pretty sure all shortened links were not working. The issue was
    that the url returned by longurl wasn't being set to replace
    the current one for the yql query, so the yql query ran on
    the short url and that doesn't follow redirects.

2: insertCode, using append, was moving already resolved instances
    on the tabs on unscatter.com. Since the same url may come up
    for multiple searches I needed the created nodes to be clones
    not indivual instances that got moved.

3: I modified the open graph output to put images or videos first
    so that I could float left them in css and have the output
    look nicer. One improvement that could be done here is to
    have the ability pass templates, say underscore ones so
    that it's easier to manage display. Or just have the option
    to return an object with the data that could be passed to
    a template.
4: onEmebed was being overwritten by insertCode if passed as a
    setting. While you could add the third argument as the
    embedAction function, it didn't make sense that onEmbed
    was actually overwritten if passed. I did not remove
    embedAction in order to break backwards compatibility but
    I would suggest deprecating it.
1. (edit, forgot one) I made the handle that allows you to display or 
       hide the content optional with a default of off. I realize this breaks
       backwards compatibility, sorry about that.
