### PR TITLE
Bug with YouTube returning a thumbnail_url

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -427,7 +427,7 @@
               , apiendpoint: this.apiendpoint
               , url: function(externalurl){return this.apiendpoint+'?format=json&url='+externalurl}
               , datareturn:function(results){
-					if (results.json.url || results.json.thumbnail_url) {
+					if (results.json.type != 'video' && (results.json.url || results.json.thumbnail_url)) {
 						return '<img src="' + (results.json.url || results.json.thumbnail_url) + '" />';
 					}
 					return results.json.html || ''


### PR DESCRIPTION
Added a test of the oEmbed type to make sure we don't return the Thumbnail if the type is video.
