### PR TITLE
Existence check for title in oembedData object.

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -396,7 +396,7 @@
     };
 
     $.fn.oembed.getGenericCode = function(url, oembedData) {
-        var title = (oembedData.title !== null) ? oembedData.title : url,
+        var title = ((oembedData.title) && (oembedData.title !== null)) ? oembedData.title : url,
             code = '<a href="' + url + '">' + title + '</a>';
         if (oembedData.html) code += "<div>" + oembedData.html + "</div>";
         return code;


### PR DESCRIPTION
Checks to make sure that oembedData.title even exists within the object; failure to exist results in 'undefined' to be inserted in the link. At least one third party (Flickr) fails to return this object with a title attribute.

Example:
http://www.flickr.com/photos/ahattar/8158065331/lightbox/
Goes to a login page, but an attempt to embed will return a 'success' result without a title object.
