### PR TITLE
oEmbed short URL https issue

### DIFF
--- a/jquery.oembed.js
+++ b/jquery.oembed.js
@@ -81,7 +81,10 @@
 							} else {
 								settings.onProviderNotFound.call(container, resourceURL);
 							}
-						  }							  
+						  },
+						  error: function() {
+                              				settings.onError.call(container, resourceURL)
+                            			  }
 						}, settings.ajaxOptions || {});
 						
 						$.ajax(ajaxopts);


### PR DESCRIPTION
When using oEmbed with a short URL (e.g. http://youtu.be/JrtWhFtjXTA) on an HTTPS page, the following error will be shown in most browsers:

```
[blocked] The page at 'https://cam.oae.com/content/cam/ZyxdB0wkZ' was loaded over HTTPS, but ran insecure content from 'http://api.longurl.org/v2/expand?callback=jQuery2000707950760377571_1406681916540&url=http%3A%2F%2Fyoutu.be%2FJrtWhFtjXTA&format=json': this content should also be loaded over HTTPS.
```

The attached pull request just ensures that the `onError` callback is called when the request to `api.longurl.org` fails, making sure that the client can appropriately react to the failure.

Unfortunately, there is no `https` version of `api.longurl.org`, so it's not possible to use that instead. An ideal solution would put something in place that allows this to work over https as well. However, this PR would still be useful to have in place regardless in case `api.longurl.org` were to go down temporarily.
